### PR TITLE
chore: Update go-unit-report from tag to SHA

### DIFF
--- a/.github/actions/unit-tests/action.yml
+++ b/.github/actions/unit-tests/action.yml
@@ -2,9 +2,9 @@ name: Unit Tests
 description: "Runs SDK's unit tests + linters and optionally gathers coverage."
 inputs:
   lint:
-    description: 'Whether to run linters.'
+    description: "Whether to run linters."
     required: false
-    default: 'false'
+    default: "false"
 
 runs:
   using: composite
@@ -25,7 +25,7 @@ runs:
       if: steps.test.outcome == 'success'
       id: process-test
       shell: bash
-      run: go run github.com/jstemmer/go-junit-report@v0.9.1 < raw_report.txt > junit_report.xml
+      run: go run github.com/jstemmer/go-junit-report@cc1f095d5cc5eca2844f5c5ea7bb37f6b9bf6cac < raw_report.txt > junit_report.xml
 
     - name: Upload test results
       if: steps.process-test.outcome == 'success'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Pins `go-junit-report` to a specific commit SHA in the unit test composite action and tweaks YAML quoting.
> 
> - **CI / GitHub Actions**
>   - **Unit Tests action (`.github/actions/unit-tests/action.yml`)**:
>     - Pin `go-junit-report` from tag `v0.9.1` to commit `cc1f095d5cc5eca2844f5c5ea7bb37f6b9bf6cac` in the test results processing step.
>     - Minor YAML string quoting normalization for `inputs.lint`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e031cd4931ced1bcc41569c7731170c48359eb0f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->