### PR TITLE
chore: add explicit permissions to release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         with:


### PR DESCRIPTION
## Summary

Adds explicit `contents: write` and `pull-requests: write` permissions to the `release-please` job. These are required for the release-please action to create release PRs and GitHub releases when the repository or organization default token permissions are set to read-only.

## Review & Testing Checklist for Human

- [ ] Verify that release-please does not need any additional permissions beyond `contents: write` and `pull-requests: write` in this repo (adding an explicit job-level `permissions` block restricts the token to *only* the listed permissions, revoking any previously inherited defaults)
- [ ] After merging, confirm that the next push to `main` triggers release-please successfully (check the Actions tab for the workflow run)

### Notes

This is part of a batch update across all `launchdarkly-sdk`-tagged repos whose release-please workflows were missing explicit permissions on their default branch.

Link to Devin session: https://app.devin.ai/sessions/a83b6e4f4fa14b96b859cfb50755a2c1
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk GitHub Actions change that only scopes token permissions for the `release-please` job. Main impact is the workflow could fail if additional permissions beyond `contents: write` and `pull-requests: write` are needed.
> 
> **Overview**
> Adds an explicit job-level `permissions` block to the `release-please` GitHub Actions workflow, granting `contents: write` and `pull-requests: write` so the action can open release PRs and create releases even when default token permissions are read-only.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 093e40a44c8c45539626dd9c76b13cdbd8b5d01b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->