### PR TITLE
chore(ci): bump fetch-api-data-action to v2.5.0 and fix renamed env var

### DIFF
--- a/.github/workflows/check-go-versions.yml
+++ b/.github/workflows/check-go-versions.yml
@@ -16,7 +16,7 @@ jobs:
         # Perform a GET request to endoflife.date for the Go language. The response
         # contains all Go releases; we're interested in the 0'th and 1'th (latest and penultimate.)
       - name: Fetch officially supported Go versions
-        uses: JamesIves/fetch-api-data-action@396ebea7d13904824f85b892b1616985f847301c # 396ebea7d13904824f85b892b1616985f847301c
+        uses: JamesIves/fetch-api-data-action@8dc51e982d982157bfd575ed64be3c48b3078037 # v2.5.0
         with:
           endpoint: https://endoflife.date/api/go.json
           configuration: '{ "method": "GET" }'
@@ -25,8 +25,8 @@ jobs:
       - name: Parse officially supported Go versions
         id: parse
         run: |
-          echo "latest=${{ fromJSON(env.fetch-api-data)[0].cycle }}" >> $GITHUB_OUTPUT
-          echo "penultimate=${{ fromJSON(env.fetch-api-data)[1].cycle }}" >> $GITHUB_OUTPUT
+          echo "latest=${{ fromJSON(env.fetchApiData)[0].cycle }}" >> $GITHUB_OUTPUT
+          echo "penultimate=${{ fromJSON(env.fetchApiData)[1].cycle }}" >> $GITHUB_OUTPUT
 
 
   create-prs:


### PR DESCRIPTION
## Summary

- Bumps `JamesIves/fetch-api-data-action` from v2.2.4 (`396ebea`) to v2.5.0 (`8dc51e9`)
- Fixes `env.fetch-api-data` → `env.fetchApiData` in the parse step of `check-go-versions.yml` — the env var was renamed in v2.3.0 and the old name is invalid on Ubuntu (dashes not allowed)

## Background

Dependabot [PR #22](https://github.com/launchdarkly/go-server-sdk-firestore/pull/22) bumps the action but leaves the stale env var name, causing a silent regression: after the bump `fromJSON(env.fetch-api-data)` always returns null, both `latest`/`penultimate` outputs become empty strings, and the downstream `create-prs` job either skips silently or creates a broken PR. CI on the Dependabot PR passes because the daily cron workflow is not exercised by the standard build checks — the breakage would only surface the next time the schedule fires post-merge.

This PR supersedes #22 and should be merged instead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change with no application runtime impact; the env var fix is required for the version bump to work on Ubuntu runners.
> 
> **Overview**
> Updates the scheduled **Check Supported Go Versions** workflow so the `JamesIves/fetch-api-data-action` step uses **v2.5.0** (pinned SHA) instead of the older v2.2.4 commit.
> 
> The parse step now reads **`env.fetchApiData`** instead of **`env.fetch-api-data`**, matching the env var rename in fetch-api-data-action v2.3.0. Without that change, the bump would leave `latest`/`penultimate` empty and break the downstream `create-prs` job when the cron runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 730265ea713850e1c1543e38b54c243f92cefa56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->