### PR TITLE
chore(ci): bump min Go version from 1.23 to 1.25 in CI matrix

### DIFF
--- a/.github/variables/go-versions.env
+++ b/.github/variables/go-versions.env
@@ -1,3 +1,3 @@
 latest=1.26
 penultimate=1.25
-min=1.23
+min=1.25


### PR DESCRIPTION
## Summary
Drop Go 1.23 from the CI matrix by setting `min=1.25` in `.github/variables/go-versions.env`. This supersedes [PR #24](https://github.com/launchdarkly/go-server-sdk-firestore/pull/24).

## Background
`setup-go@v6` (the v5→v6 Dependabot bump in PR #24) introduced a breaking change: it now sets `GOTOOLCHAIN=local`, locking CI jobs to the exact installed Go version. Under v5, `GOTOOLCHAIN` defaulted to `auto`, silently downloading a newer toolchain when `go.mod` required it — so the Go 1.23 matrix slot was never actually running Go 1.23.

With v6, the Go 1.23 job correctly refuses to build because `go.mod` requires `go >= 1.24.0`, causing two CI failures on PR #24.

The `min=1.23` value in `go-versions.env` is stale: the module already requires Go 1.24+ and open Dependabot PRs (#25, #27, #29) will push that requirement to 1.25+. Setting `min=1.25` matches `penultimate`, collapsing the matrix from `[1.26, 1.25, 1.23]` to `[1.26, 1.25]` and removing a slot that cannot build the module.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI configuration only; no runtime or application code changes.
> 
> **Overview**
> Raises the **minimum Go version** used for CI from **1.23** to **1.25** in `.github/variables/go-versions.env`, so the shared `go-versions` workflow no longer includes a third matrix slot for 1.23.
> 
> Because `min` now matches `penultimate`, the test matrix shrinks from **three versions** (`1.26`, `1.25`, `1.23`) to **two** (`1.26`, `1.25`), aligning CI with the module’s actual Go requirement and avoiding jobs that cannot build under `setup-go@v6`’s `GOTOOLCHAIN=local` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed27a6abce41692f814c8b8dfdd4e68f175fa774. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->