### PR TITLE
ci: use shared sdk-go-versions workflow

### DIFF
--- a/.github/workflows/check-go-versions.yml
+++ b/.github/workflows/check-go-versions.yml
@@ -8,14 +8,9 @@ permissions: {}
 
 jobs:
   check-go-versions:
-    # The called workflow narrows check-go-eol to `contents: read`; a reusable workflow
-    # cannot grant itself more than the caller does, which is why the write scopes are here.
     permissions:
       contents: write
       pull-requests: write
-    # Reusable workflows in gh-actions are consumed at @main; release-please does not version
-    # them (see launchdarkly/gh-actions#51). The composite action that workflow calls is
-    # pinned to an exact release tag on that side.
     uses: launchdarkly/gh-actions/.github/workflows/sdk-go-versions.yml@main
     with:
       branches: '["main"]'

--- a/.github/workflows/check-go-versions.yml
+++ b/.github/workflows/check-go-versions.yml
@@ -7,85 +7,15 @@ on:
 permissions: {}
 
 jobs:
-  check-go-eol:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      latest: ${{ steps.parse.outputs.latest }}
-      penultimate: ${{ steps.parse.outputs.penultimate }}
-    timeout-minutes: 2
-    steps:
-        # Perform a GET request to endoflife.date for the Go language. The response
-        # contains all Go releases; we're interested in the 0'th and 1'th (latest and penultimate.)
-      - name: Fetch officially supported Go versions
-        uses: JamesIves/fetch-api-data-action@1df37d52090c0a251f252c7ba247d2aba1d408ae # v2.5.2
-        with:
-          endpoint: https://endoflife.date/api/go.json
-          configuration: '{ "method": "GET" }'
-          debug: true
-        # Parse the response JSON and insert into environment variables for the next step.
-      - name: Parse officially supported Go versions
-        id: parse
-        env:
-          FETCH_API_DATA: ${{ env.fetchApiData }}
-        run: |
-          set -euo pipefail
-          latest=$(jq -r '.[0].cycle' <<< "$FETCH_API_DATA")
-          penultimate=$(jq -r '.[1].cycle' <<< "$FETCH_API_DATA")
-          for version in "$latest" "$penultimate"; do
-            if [[ ! "$version" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
-              echo "Unexpected Go version string from endoflife.date: $version" >&2
-              exit 1
-            fi
-          done
-          echo "latest=$latest" >> "$GITHUB_OUTPUT"
-          echo "penultimate=$penultimate" >> "$GITHUB_OUTPUT"
-
-
-  create-prs:
+  check-go-versions:
+    # The called workflow narrows check-go-eol to `contents: read`; a reusable workflow
+    # cannot grant itself more than the caller does, which is why the write scopes are here.
     permissions:
       contents: write
       pull-requests: write
-    needs: check-go-eol
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        branch: ["main"]
-      fail-fast: false
-    env:
-      officialLatestVersion: ${{ needs.check-go-eol.outputs.latest }}
-      officialPenultimateVersion: ${{ needs.check-go-eol.outputs.penultimate }}
-    steps:
-      - uses: actions/checkout@v7.0.1
-        with:
-          ref: ${{ matrix.branch }}
-
-      - name: Get current Go versions
-        id: go-versions
-        run:  cat ./.github/variables/go-versions.env >> "$GITHUB_OUTPUT"
-
-      - name: Update go-versions.env and README.md
-        if: steps.go-versions.outputs.latest != env.officialLatestVersion
-        id: update-go-versions
-        run: |
-          set -euo pipefail
-          sed -i -e "s#latest=[^ ]*#latest=$officialLatestVersion#g" \
-                 -e "s#penultimate=[^ ]*#penultimate=$officialPenultimateVersion#g" \
-                  ./.github/variables/go-versions.env
-
-      - name: Create pull request
-        if: steps.update-go-versions.outcome == 'success'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          add-paths: |
-            .github/variables/go-versions.env
-          branch: "launchdarklyreleasebot/update-to-go${{ env.officialLatestVersion }}-${{ matrix.branch }}"
-          author: "LaunchDarklyReleaseBot <LaunchDarklyReleaseBot@launchdarkly.com>"
-          committer: "LaunchDarklyReleaseBot <LaunchDarklyReleaseBot@launchdarkly.com>"
-          labels: ${{ matrix.branch }}
-          title: "ci: bump tested Go versions to ${{ env.officialLatestVersion }} and ${{ env.officialPenultimateVersion }}"
-          commit-message: "Bumps from Go ${{ steps.go-versions.outputs.latest }} -> ${{ env.officialLatestVersion }} and ${{ steps.go-versions.outputs.penultimate }} -> ${{ env.officialPenultimateVersion }}."
-          body: |
-            - [ ] I have triggered CI on this PR (either close & reopen this PR in Github UI, or `git commit -m "run ci" --allow-empty && git push`)
+    # Reusable workflows in gh-actions are consumed at @main; release-please does not version
+    # them (see launchdarkly/gh-actions#51). The composite action that workflow calls is
+    # pinned to an exact release tag on that side.
+    uses: launchdarkly/gh-actions/.github/workflows/sdk-go-versions.yml@main
+    with:
+      branches: '["main"]'

--- a/.github/workflows/check-go-versions.yml
+++ b/.github/workflows/check-go-versions.yml
@@ -4,15 +4,18 @@ on:
     - cron: "0 17 * * *"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   check-go-eol:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       latest: ${{ steps.parse.outputs.latest }}
       penultimate: ${{ steps.parse.outputs.penultimate }}
     timeout-minutes: 2
     steps:
-      - uses: actions/checkout@v7.0.1
         # Perform a GET request to endoflife.date for the Go language. The response
         # contains all Go releases; we're interested in the 0'th and 1'th (latest and penultimate.)
       - name: Fetch officially supported Go versions
@@ -24,9 +27,20 @@ jobs:
         # Parse the response JSON and insert into environment variables for the next step.
       - name: Parse officially supported Go versions
         id: parse
+        env:
+          FETCH_API_DATA: ${{ env.fetchApiData }}
         run: |
-          echo "latest=${{ fromJSON(env.fetchApiData)[0].cycle }}" >> $GITHUB_OUTPUT
-          echo "penultimate=${{ fromJSON(env.fetchApiData)[1].cycle }}" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          latest=$(jq -r '.[0].cycle' <<< "$FETCH_API_DATA")
+          penultimate=$(jq -r '.[1].cycle' <<< "$FETCH_API_DATA")
+          for version in "$latest" "$penultimate"; do
+            if [[ ! "$version" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+              echo "Unexpected Go version string from endoflife.date: $version" >&2
+              exit 1
+            fi
+          done
+          echo "latest=$latest" >> "$GITHUB_OUTPUT"
+          echo "penultimate=$penultimate" >> "$GITHUB_OUTPUT"
 
 
   create-prs:
@@ -49,14 +63,15 @@ jobs:
 
       - name: Get current Go versions
         id: go-versions
-        run:  cat ./.github/variables/go-versions.env > $GITHUB_OUTPUT
+        run:  cat ./.github/variables/go-versions.env >> "$GITHUB_OUTPUT"
 
       - name: Update go-versions.env and README.md
         if: steps.go-versions.outputs.latest != env.officialLatestVersion
         id: update-go-versions
         run: |
-          sed -i -e "s#latest=[^ ]*#latest=${{ env.officialLatestVersion }}#g" \
-                 -e "s#penultimate=[^ ]*#penultimate=${{ env.officialPenultimateVersion }}#g" \
+          set -euo pipefail
+          sed -i -e "s#latest=[^ ]*#latest=$officialLatestVersion#g" \
+                 -e "s#penultimate=[^ ]*#penultimate=$officialPenultimateVersion#g" \
                   ./.github/variables/go-versions.env
 
       - name: Create pull request


### PR DESCRIPTION
Replaces this repo's copy of the Go version check with a call to the shared `sdk-go-versions` reusable workflow, deleting the inline shell entirely.

### Why this supersedes the previous approach

The earlier revision of this PR hardened the inline shell in place (the port of launchdarkly/ld-relay#841, SEC-9481): quoted env vars, `jq` extraction, strict version validation. That fixed the injection vector but left the shell here to be re-broken later.

Calling the shared workflow removes the shell from this repo altogether, so the script-injection class is structurally unavailable here rather than merely fixed. 91 lines become 21.

The shared workflow pins the composite action to the released `go-eol-versions-v0.1.0`; consumers track the workflow itself at `@main`, matching how this repo already consumes `sdk-stale` and `dependency-scan` (reusable workflows in gh-actions are not versioned by release-please — see launchdarkly/gh-actions#51).

### Inputs

- `branches: '["main"]'` — required, JSON array string. This repo only maintains `main`, which is what the old `strategy.matrix.branch` listed.

Everything else is left at its default: `precision` (`cycle`), `versions_file` (`.github/variables/go-versions.env`), `update_script`, `add_paths`, `pr_title_prefix` and `runs_on` all default to what this repo needs.

The `permissions:` block on the caller job grants `contents: write` / `pull-requests: write` because a reusable workflow cannot grant itself more than the caller does; the called workflow narrows its own `check-go-eol` job back down to `contents: read`.

### Behaviour

Intended to be unchanged: same schedule (`0 17 * * *`), same file updated (`.github/variables/go-versions.env`), same PR shape (same title format, same LaunchDarklyReleaseBot author/committer, same branch label).

Two fixes the shared version carries that this repo's inline copy did not:

- A penultimate-only upstream release now opens a PR. The inline gate was `if: steps.go-versions.outputs.latest != env.officialLatestVersion`, so a change to only the penultimate version was silently skipped.
- The bot branch name includes both versions, so a latest-unchanged/penultimate-changed bump does not collide with an existing branch.

### Verification

- YAML parses and the job resolves as a single reusable-workflow call: `python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/check-go-versions.yml')); print(d['jobs'])"` → one `check-go-versions` job with `uses:`, `with:` and `permissions:` only.
- No `run:` steps remain anywhere in the file: `grep -c 'run:'` → 0.
- No trace of the old implementation: `grep -c 'fromJSON\|JamesIves\|peter-evans\|sed -i'` → 0.
- Diff scope: `git diff --stat` against `main` touches only `.github/workflows/check-go-versions.yml` (11 insertions, 66 deletions).
- Not dispatched from this repo — the shared workflow is already verified end to end in go-test-helpers ([run 33534426032](https://github.com/launchdarkly/go-test-helpers/actions/runs/33534426032)), and a dispatch here could open a real bump PR.
- Test coverage: n/a — workflow-only change.

Tracked by SDK-3023.
Shared workflow: launchdarkly/gh-actions#113.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **Replaces the local Go version bump automation** with a single call to `launchdarkly/gh-actions/.github/workflows/sdk-go-versions.yml@main`, removing all inline `run:` steps (API fetch, `sed` updates, and `create-pull-request`).
> 
> The workflow still runs on the same schedule and targets `main` via `branches: '["main"]'`, with the caller job granting `contents: write` and `pull-requests: write` so the reusable workflow can open bump PRs. Centralizing the logic in gh-actions removes script-injection risk from this repo and aligns with how other SDK workflows (e.g. stale) consume shared actions.
> 
> The shared workflow is intended to preserve the same PR shape while also opening bumps when only the penultimate Go version changes and using branch names that include both versions to avoid collisions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7ecad43a090e2eab5147b4156ceb87ce1d7b81c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->